### PR TITLE
Add Sharding Annotations to Flax Modules

### DIFF
--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -42,6 +42,7 @@ from flax.typing import (
   Initializer,
   PrecisionLike,
   DotGeneralT,
+  Tuple,
 )
 
 def dot_product_attention_weights(

--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -42,7 +42,6 @@ from flax.typing import (
   Initializer,
   PrecisionLike,
   DotGeneralT,
-  Tuple,
 )
 
 def dot_product_attention_weights(

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -117,8 +117,8 @@ class DenseGeneral(Module):
   # Deprecated. Will be removed.
   dot_general: DotGeneralT | None = None
   dot_general_cls: Any = None
-  kernel_axes: Tuple[str, ...] = None
-  bias_axes: Tuple[str, ...] = None
+  kernel_axes: tuple[str, ...] = None
+  bias_axes: tuple[str, ...] = None
 
   @compact
   def __call__(self, inputs: Array) -> Array:
@@ -260,8 +260,8 @@ class Dense(Module):
   # Deprecated. Will be removed.
   dot_general: DotGeneralT | None = None
   dot_general_cls: Any = None
-  kernel_axes: Tuple[str, ...] = None
-  bias_axes: Tuple[str, ...] = None
+  kernel_axes: tuple[str, ...] = None
+  bias_axes: tuple[str, ...] = None
 
   @compact
   def __call__(self, inputs: Array) -> Array:
@@ -535,8 +535,8 @@ class _Conv(Module):
   # Deprecated. Will be removed.
   conv_general_dilated: ConvGeneralDilatedT | None = None
   conv_general_dilated_cls: Any = None
-  kernel_axes: Tuple[str, ...] = None
-  bias_axes: Tuple[str, ...] = None
+  kernel_axes: tuple[str, ...] = None
+  bias_axes: tuple[str, ...] = None
 
   @property
   def shared_weights(self) -> bool:  # type: ignore
@@ -971,8 +971,8 @@ class ConvTranspose(Module):
     name: str,
     init_fn,
     *init_args,
-    axes: Optional[Tuple[str, ...]] = None,
-    module: Optional[Module] = None):
+    axes: tuple[str, ...] | None = None,
+    module: Module | None = None):
     return param_with_axes(
       name,
       init_fn,

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -34,7 +34,6 @@ from flax.typing import (
     PaddingLike,
     PrecisionLike,
     Shape as Shape,
-    Tuple,
 )
 import jax
 from jax import eval_shape, lax

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -22,6 +22,7 @@ from flax.linen import initializers
 from flax.linen import module
 from flax.linen.dtypes import promote_dtype
 from flax.linen.module import Module, compact
+from flax.linen.partitioning import param_with_axes
 from flax.typing import (
     Array,
     ConvGeneralDilatedT,
@@ -94,10 +95,15 @@ class DenseGeneral(Module):
     bias_init: initializer function for the bias.
     precision: numerical precision of the computation see ``jax.lax.Precision``
       for details.
+<<<<<<< HEAD
     promote_dtype: function to promote the dtype of the arrays to the desired
       dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
       and a ``dtype`` keyword argument, and return a tuple of arrays with the
       promoted dtype.
+=======
+    kernel_axes: a tuple of axes associated with the kernel.
+    bias_axes: a tuple of axes associated with the bias.
+>>>>>>> add t5x sharding annotations to flax layers
   """
 
   features: int | Sequence[int]
@@ -113,6 +119,8 @@ class DenseGeneral(Module):
   # Deprecated. Will be removed.
   dot_general: DotGeneralT | None = None
   dot_general_cls: Any = None
+  kernel_axes: Tuple[str, ...] = None
+  bias_axes: Tuple[str, ...] = None
 
   @compact
   def __call__(self, inputs: Array) -> Array:
@@ -161,8 +169,9 @@ class DenseGeneral(Module):
       if ax not in axis
     )
     kernel_shape = tuple(inputs.shape[ax] for ax in axis) + features
-    kernel = self.param(
-      'kernel', kernel_init_wrap, batch_shape + kernel_shape, self.param_dtype
+    kernel = param_with_axes(
+      'kernel', kernel_init_wrap, batch_shape + kernel_shape,
+      self.param_dtype, axes=self.kernel_axes
     )
 
     batch_ind = tuple(range(n_batch_dims))
@@ -180,9 +189,11 @@ class DenseGeneral(Module):
           return meta.replace_boxed(bias, jnp.reshape(bias.unbox(), shape))
         return jnp.reshape(bias, shape)
 
-      bias = self.param(
-        'bias', bias_init_wrap, batch_shape + features, self.param_dtype
+      bias = param_with_axes(
+        'bias', bias_init_wrap, batch_shape + features,
+        self.param_dtype, axes=self.bias_axes
       )
+
     else:
       bias = None
 
@@ -232,10 +243,15 @@ class Dense(Module):
       for details.
     kernel_init: initializer function for the weight matrix.
     bias_init: initializer function for the bias.
+<<<<<<< HEAD
     promote_dtype: function to promote the dtype of the arrays to the desired
       dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
       and a ``dtype`` keyword argument, and return a tuple of arrays with the
       promoted dtype.
+=======
+    kernel_axes: a tuple of axes associated with the kernel.
+    bias_axes: a tuple of axes associated with the bias.
+>>>>>>> add t5x sharding annotations to flax layers
   """
 
   features: int
@@ -249,6 +265,8 @@ class Dense(Module):
   # Deprecated. Will be removed.
   dot_general: DotGeneralT | None = None
   dot_general_cls: Any = None
+  kernel_axes: Tuple[str, ...] = None
+  bias_axes: Tuple[str, ...] = None
 
   @compact
   def __call__(self, inputs: Array) -> Array:
@@ -260,15 +278,18 @@ class Dense(Module):
     Returns:
       The transformed input.
     """
-    kernel = self.param(
+    kernel = param_with_axes(
       'kernel',
       self.kernel_init,
       (jnp.shape(inputs)[-1], self.features),
       self.param_dtype,
+      axes=self.kernel_axes
     )
     if self.use_bias:
-      bias = self.param(
-        'bias', self.bias_init, (self.features,), self.param_dtype
+      bias = param_with_axes(
+        'bias', self.bias_init, (self.features,),
+        self.param_dtype,
+        axes=self.bias_axes
       )
     else:
       bias = None
@@ -493,10 +514,15 @@ class _Conv(Module):
       for details.
     kernel_init: initializer for the convolutional kernel.
     bias_init: initializer for the bias.
+<<<<<<< HEAD
     promote_dtype: function to promote the dtype of the arrays to the desired
       dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
       and a ``dtype`` keyword argument, and return a tuple of arrays with the
       promoted dtype.
+=======
+    kernel_axes: a tuple of axes associated with the kernel.
+    bias_axes: a tuple of axes associated with the bias.
+>>>>>>> add t5x sharding annotations to flax layers
   """
 
   features: int
@@ -517,6 +543,8 @@ class _Conv(Module):
   # Deprecated. Will be removed.
   conv_general_dilated: ConvGeneralDilatedT | None = None
   conv_general_dilated_cls: Any = None
+  kernel_axes: Tuple[str, ...] = None
+  bias_axes: Tuple[str, ...] = None
 
   @property
   def shared_weights(self) -> bool:  # type: ignore
@@ -659,8 +687,10 @@ class _Conv(Module):
         f'Shapes are: {self.mask.shape}, {kernel_shape}'
       )
 
-    kernel = self.param(
-      'kernel', self.kernel_init, kernel_shape, self.param_dtype
+    kernel = param_with_axes(
+      'kernel', self.kernel_init, kernel_shape,
+      self.param_dtype,
+      axes=self.kernel_axes
     )
 
     if self.mask is not None:
@@ -674,7 +704,7 @@ class _Conv(Module):
         # One bias weight per output entry, unshared betwen pixels.
         bias_shape = conv_output_shape[1:]
 
-      bias = self.param('bias', self.bias_init, bias_shape, self.param_dtype)
+      bias = param_with_axes('bias', self.bias_init, bias_shape, self.param_dtype, axes=self.bias_axes)
     else:
       bias = None
 

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -974,6 +974,21 @@ class ConvTranspose(Module):
   transpose_kernel: bool = False
   promote_dtype: PromoteDtypeFn = promote_dtype
 
+  def param_with_axes(
+    self,
+    name: str,
+    init_fn,
+    *init_args,
+    axes: Optional[Tuple[str, ...]] = None,
+    module: Optional[Module] = None):
+    return param_with_axes(
+      name,
+      init_fn,
+      *init_args,
+      axes=axes,
+      module=module,
+    )
+
   @compact
   def __call__(self, inputs: Array) -> Array:
     """Applies a transposed convolution to the inputs.
@@ -1037,8 +1052,9 @@ class ConvTranspose(Module):
         f'Shapes are: {self.mask.shape}, {kernel_shape}'
       )
 
-    kernel = self.param(
-      'kernel', self.kernel_init, kernel_shape, self.param_dtype
+    kernel = self.param_with_axes(
+      'kernel', self.kernel_init, kernel_shape, self.param_dtype,
+      axes=('height', 'width', 'input', 'embed')
     )
 
     if self.mask is not None:
@@ -1049,8 +1065,8 @@ class ConvTranspose(Module):
       padding_lax = 'VALID'
 
     if self.use_bias:
-      bias = self.param(
-        'bias', self.bias_init, (self.features,), self.param_dtype
+      bias = self.param_with_axes(
+        'bias', self.bias_init, (self.features,), self.param_dtype, axes=('embed', )
       )
     else:
       bias = None

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -34,6 +34,7 @@ from flax.typing import (
     PaddingLike,
     PrecisionLike,
     Shape as Shape,
+    Tuple,
 )
 import jax
 from jax import eval_shape, lax
@@ -95,15 +96,12 @@ class DenseGeneral(Module):
     bias_init: initializer function for the bias.
     precision: numerical precision of the computation see ``jax.lax.Precision``
       for details.
-<<<<<<< HEAD
     promote_dtype: function to promote the dtype of the arrays to the desired
       dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
       and a ``dtype`` keyword argument, and return a tuple of arrays with the
       promoted dtype.
-=======
     kernel_axes: a tuple of axes associated with the kernel.
     bias_axes: a tuple of axes associated with the bias.
->>>>>>> add t5x sharding annotations to flax layers
   """
 
   features: int | Sequence[int]
@@ -243,15 +241,12 @@ class Dense(Module):
       for details.
     kernel_init: initializer function for the weight matrix.
     bias_init: initializer function for the bias.
-<<<<<<< HEAD
     promote_dtype: function to promote the dtype of the arrays to the desired
       dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
       and a ``dtype`` keyword argument, and return a tuple of arrays with the
       promoted dtype.
-=======
     kernel_axes: a tuple of axes associated with the kernel.
     bias_axes: a tuple of axes associated with the bias.
->>>>>>> add t5x sharding annotations to flax layers
   """
 
   features: int
@@ -514,15 +509,12 @@ class _Conv(Module):
       for details.
     kernel_init: initializer for the convolutional kernel.
     bias_init: initializer for the bias.
-<<<<<<< HEAD
     promote_dtype: function to promote the dtype of the arrays to the desired
       dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
       and a ``dtype`` keyword argument, and return a tuple of arrays with the
       promoted dtype.
-=======
     kernel_axes: a tuple of axes associated with the kernel.
     bias_axes: a tuple of axes associated with the bias.
->>>>>>> add t5x sharding annotations to flax layers
   """
 
   features: int

--- a/flax/linen/normalization.py
+++ b/flax/linen/normalization.py
@@ -33,6 +33,7 @@ from flax.typing import (
   Shape as Shape,
   Initializer,
   Axes,
+  Tuple,
 )
 
 field = dataclasses.field

--- a/flax/linen/normalization.py
+++ b/flax/linen/normalization.py
@@ -33,7 +33,6 @@ from flax.typing import (
   Shape as Shape,
   Initializer,
   Axes,
-  Tuple,
 )
 
 field = dataclasses.field
@@ -163,7 +162,7 @@ def _normalize(
   bias_init: Initializer,
   scale_init: Initializer,
   force_float32_reductions: bool = True,
-  axes: Tuple[str, ...] = None,
+  axes: tuple[str, ...] = None,
 ):
   """Normalizes the input of a normalization layer and optionally applies a learned scale and bias.
 
@@ -321,7 +320,7 @@ class BatchNorm(Module):
   axis_index_groups: Any = None
   use_fast_variance: bool = True
   force_float32_reductions: bool = True
-  pjit_axis_name: Tuple[str, ...] = None
+  pjit_axis_name: tuple[str, ...] = None
 
   @compact
   def __call__(
@@ -501,7 +500,7 @@ class LayerNorm(Module):
   axis_index_groups: Any = None
   use_fast_variance: bool = True
   force_float32_reductions: bool = True
-  pjit_axis_name: Tuple[str, ...] = None
+  pjit_axis_name: tuple[str, ...] = None
 
   @compact
   def __call__(self, x, *, mask: jax.Array | None = None):
@@ -604,7 +603,7 @@ class RMSNorm(Module):
   axis_index_groups: Any = None
   use_fast_variance: bool = True
   force_float32_reductions: bool = True
-  pjit_axis_name: Tuple[str, ...] = None
+  pjit_axis_name: tuple[str, ...] = None
 
   @compact
   def __call__(self, x, *, mask: jax.Array | None = None):
@@ -733,7 +732,7 @@ class GroupNorm(Module):
   axis_index_groups: Any = None
   use_fast_variance: bool = True
   force_float32_reductions: bool = True
-  pjit_axis_name: Tuple[str, ...] = None
+  pjit_axis_name: tuple[str, ...] = None
 
   @compact
   def __call__(self, x, *, mask: jax.Array | None = None):

--- a/flax/linen/normalization.py
+++ b/flax/linen/normalization.py
@@ -25,6 +25,7 @@ from jax import lax
 from jax.nn import initializers
 
 from flax.linen import dtypes, module, transforms
+from flax.linen.partitioning import param_with_axes
 from flax.typing import (
   Array,
   PRNGKey as PRNGKey,
@@ -160,7 +161,8 @@ def _normalize(
   use_scale: bool,
   bias_init: Initializer,
   scale_init: Initializer,
-  force_float32_reductions: bool = True
+  force_float32_reductions: bool = True,
+  axes: Tuple[str, ...] = None,
 ):
   """Normalizes the input of a normalization layer and optionally applies a learned scale and bias.
 
@@ -183,6 +185,7 @@ def _normalize(
     force_float32_reductions: If false, the scale and bias parameters use the
       param_dtype. Otherwise, they will have at least float32 precision due to
       the mean and var being promoted to float32.
+    axes: A tuple of axis names over which to shard parameters.
 
   Returns:
     The normalized input.
@@ -201,8 +204,9 @@ def _normalize(
   mul = lax.rsqrt(var + epsilon)
   args = [x]
   if use_scale:
-    scale = mdl.param(
-      'scale', scale_init, reduced_feature_shape, param_dtype
+    scale = param_with_axes(
+      'scale', scale_init, reduced_feature_shape,
+      param_dtype, axes=axes, module=mdl
     ).reshape(feature_shape)
     if not force_float32_reductions:
       scale = jnp.asarray(scale, param_dtype)
@@ -210,8 +214,9 @@ def _normalize(
     args.append(scale)
   y *= mul
   if use_bias:
-    bias = mdl.param(
-      'bias', bias_init, reduced_feature_shape, param_dtype
+    bias = param_with_axes(
+      'bias', bias_init, reduced_feature_shape,
+      param_dtype, axes=axes, module=mdl
     ).reshape(feature_shape)
     if not force_float32_reductions:
       bias = jnp.asarray(bias, param_dtype)
@@ -298,6 +303,7 @@ class BatchNorm(Module):
       more details.
     use_fast_variance: If true, use a faster, but less numerically stable,
       calculation for the variance.
+    pjit_axis_names: A tuple of axis names.
   """
 
   use_running_average: bool | None = None
@@ -314,6 +320,7 @@ class BatchNorm(Module):
   axis_index_groups: Any = None
   use_fast_variance: bool = True
   force_float32_reductions: bool = True
+  pjit_axis_name: Tuple[str, ...] = None
 
   @compact
   def __call__(
@@ -413,6 +420,7 @@ class BatchNorm(Module):
       self.bias_init,
       self.scale_init,
       self.force_float32_reductions,
+      self.pjit_axis_name,
     )
 
 
@@ -476,6 +484,7 @@ class LayerNorm(Module):
       more details.
     use_fast_variance: If true, use a faster, but less numerically stable,
       calculation for the variance.
+    pjit_axis_names: A tuple of axis names.
   """
 
   epsilon: float = 1e-6
@@ -491,6 +500,7 @@ class LayerNorm(Module):
   axis_index_groups: Any = None
   use_fast_variance: bool = True
   force_float32_reductions: bool = True
+  pjit_axis_name: Tuple[str, ...] = None
 
   @compact
   def __call__(self, x, *, mask: jax.Array | None = None):
@@ -530,6 +540,7 @@ class LayerNorm(Module):
       self.bias_init,
       self.scale_init,
       self.force_float32_reductions,
+      self.pjit_axis_name,
     )
 
 
@@ -578,6 +589,7 @@ class RMSNorm(Module):
       more details.
     use_fast_variance: If true, use a faster, but less numerically stable,
       calculation for the variance.
+    pjit_axis_names: A tuple of axis names.
   """
 
   epsilon: float = 1e-6
@@ -591,6 +603,7 @@ class RMSNorm(Module):
   axis_index_groups: Any = None
   use_fast_variance: bool = True
   force_float32_reductions: bool = True
+  pjit_axis_name: Tuple[str, ...] = None
 
   @compact
   def __call__(self, x, *, mask: jax.Array | None = None):
@@ -631,6 +644,7 @@ class RMSNorm(Module):
       initializers.zeros,
       self.scale_init,
       self.force_float32_reductions,
+      self.pjit_axis_name,
     )
 
 
@@ -701,6 +715,7 @@ class GroupNorm(Module):
       more details.
     use_fast_variance: If true, use a faster, but less numerically stable,
       calculation for the variance.
+    pjit_axis_names: A tuple of axis names.
   """
 
   num_groups: int | None = 32
@@ -717,6 +732,7 @@ class GroupNorm(Module):
   axis_index_groups: Any = None
   use_fast_variance: bool = True
   force_float32_reductions: bool = True
+  pjit_axis_name: Tuple[str, ...] = None
 
   @compact
   def __call__(self, x, *, mask: jax.Array | None = None):
@@ -936,6 +952,7 @@ class InstanceNorm(Module):
       self.bias_init,
       self.scale_init,
       self.force_float32_reductions,
+      self.pjit_axis_name,
     )
 
 


### PR DESCRIPTION
Adds sharding annotations to Flax's `Dense`, `DenseGeneral`, `MultiHeadDotProductAttention` and normalization modules. This change makes Flax's modules compatible with [T5X](https://github.com/google-research/t5x).